### PR TITLE
Fixed dotnet-core.yaml to properly check branch when running.

### DIFF
--- a/.github/workflows/dotnet-core.yaml
+++ b/.github/workflows/dotnet-core.yaml
@@ -35,11 +35,11 @@ jobs:
         run: dotnet test --no-restore --verbosity normal
 
       - name: Publish
-        if: github.ref == 'refs/head/master'
+        if: github.ref == 'refs/heads/master'
         run: dotnet publish --configuration Release --output 'dotnetcorewebapp'
 
       - name: 'Deploy to Azure App Services 😎'
-        if: github.ref == 'refs/head/master'
+        if: github.ref == 'refs/heads/master'
         uses: 'azure/webapps-deploy@v2'
         with:
           app-name: ${{ env.AZURE_WEBAPP_NAME }}


### PR DESCRIPTION
'If' condition in the yaml file was checking `refs/head/master` instead of `refs/heads/master`. (Note that 'head' needed to be pluralized)